### PR TITLE
Derive more traits and allow iteration over &Pages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,15 @@ impl Iterator for Pages {
     }
 }
 
+impl IntoIterator for &Pages {
+    type Item = Page;
+    type IntoIter = Pages;
+
+    fn into_iter(self) -> Pages {
+        self.clone()
+    }
+}
+
 /// Defines the properties of a page.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Page {
@@ -225,6 +234,16 @@ mod tests {
         let items_per_page = 1usize;
         let pages = Pages::new(total_items, items_per_page);
         for p in pages.into_iter() {
+            assert_eq!(p, Page { offset: 0, length: 1, start: 0, end: 0 });
+        }
+    }
+
+    #[test]
+    fn iterator_ref() {
+        let total_items = 1usize;
+        let items_per_page = 1usize;
+        let pages = Pages::new(total_items, items_per_page);
+        for p in &pages {
             assert_eq!(p, Page { offset: 0, length: 1, start: 0, end: 0 });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use std::cmp::{max, min};
 
 ///
 /// Defines the pages to facilitate pagination.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Pages {
     /// Current page offset.
     offset: usize,
@@ -109,7 +109,7 @@ impl Iterator for Pages {
 }
 
 /// Defines the properties of a page.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Page {
     /// The current page offset.
     pub offset: usize,


### PR DESCRIPTION
Deriving `Clone` for `Page` and `Pages` is helpful for some usecases, and we might as well derive `Eq` because equality on them is an equivalence relation. Implementing `IntoIterator` on `&Pages` allows iteration without moving the `Pages` or modifying it, which is useful e.g. when it is contained in another struct.