### PR TITLE
Add method to get number of pages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,11 @@ impl Pages {
     pub fn limit(&self) -> usize {
         self.limit
     }
+
+    /// Gets the total number of pages.
+    pub fn page_count(&self) -> usize {
+        (self.length + self.limit - 1) / self.limit
+    }
 }
 
 impl Iterator for Pages {
@@ -251,10 +256,21 @@ mod tests {
         assert_eq!(100, pages.length());
     }
 
-
     #[test]
     fn limit() {
         let pages = Pages::new(100, 5);
         assert_eq!(5, pages.limit());
+    }
+
+    #[test]
+    fn page_count() {
+        let pages = Pages::new(100, 5);
+        assert_eq!(20, pages.page_count());
+
+        let pages = Pages::new(101, 5);
+        assert_eq!(21, pages.page_count());
+
+        let pages = Pages::new(99, 5);
+        assert_eq!(20, pages.page_count());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl Pages {
         self.offset
     }
 
-    /// Gets the total number of pages.
+    /// Gets the total number of items.
     pub fn length(&self) -> usize {
         self.length
     }


### PR DESCRIPTION
The documentation for `Pages::length` claimed that it would return the total number of pages, but in fact it returns the total number of items. This fixes the documentation, and adds a new `page_count` method that actually returns the total number of pages.